### PR TITLE
Legg til LRU-cache for opplastet korpus

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,9 @@ authors = [
 dependencies = [
     "dhlab>=2.41.0",
     "flask>=3.0.3",
+    "flask-cors>=5.0.0",
     "gunicorn>=23.0.0",
+    "jinja-partials>=0.2.1",
     "jinja2>=3.1.4",
 ]
 

--- a/src/dhlab_corpus_webapp/app.py
+++ b/src/dhlab_corpus_webapp/app.py
@@ -177,9 +177,7 @@ def create_corpus(corpus_metadata: CorpusMetadata) -> dh.Corpus:
     return dh_corpus_object
 
 
-#@lru_cache
-def speadsheet_to_corpus(file) -> dict:
-    
+def speadsheet_to_corpus(file) -> dh.Corpus:
     uploaded_file = file.get('spreadsheet')
     
     if uploaded_file.filename.endswith('.csv'):
@@ -189,10 +187,14 @@ def speadsheet_to_corpus(file) -> dict:
         df = pd.read_excel(uploaded_file)
 
     urn_list = df["urn"].dropna().tolist() 
-    #session['urn_list'] = urn_list
+    
+    return urn_list_to_corpus(tuple(urn_list))
 
+
+@lru_cache
+def urn_list_to_corpus(urn_list: tuple[str]) -> dh.Corpus:
     corpus = dh.Corpus()
-    corpus.extend_from_identifiers(urn_list)
+    corpus.extend_from_identifiers(list(urn_list))
     return corpus
 
 CORPUS_COLUMNS: dict[str, list[str]] = {

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
 wheels = [
@@ -186,7 +186,9 @@ source = { editable = "." }
 dependencies = [
     { name = "dhlab" },
     { name = "flask" },
+    { name = "flask-cors" },
     { name = "gunicorn" },
+    { name = "jinja-partials" },
     { name = "jinja2" },
 ]
 
@@ -199,7 +201,9 @@ dev = [
 requires-dist = [
     { name = "dhlab", specifier = ">=2.41.0" },
     { name = "flask", specifier = ">=3.0.3" },
+    { name = "flask-cors", specifier = ">=5.0.0" },
     { name = "gunicorn", specifier = ">=23.0.0" },
+    { name = "jinja-partials", specifier = ">=0.2.1" },
     { name = "jinja2", specifier = ">=3.1.4" },
 ]
 
@@ -238,6 +242,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/41/e1/d104c83026f8d35dfd2c261df7d64738341067526406b40190bc063e829a/flask-3.0.3.tar.gz", hash = "sha256:ceb27b0af3823ea2737928a4d99d125a06175b8512c445cbd9a9ce200ef76842", size = 676315 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/80/ffe1da13ad9300f87c93af113edd0638c75138c42a0994becfacac078c06/flask-3.0.3-py3-none-any.whl", hash = "sha256:34e815dfaa43340d1d15a5c3a02b8476004037eb4840b34910c6e21679d288f3", size = 101735 },
+]
+
+[[package]]
+name = "flask-cors"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flask" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/d0/d9e52b154e603b0faccc0b7c2ad36a764d8755ef4036acbf1582a67fb86b/flask_cors-5.0.0.tar.gz", hash = "sha256:5aadb4b950c4e93745034594d9f3ea6591f734bb3662e16e255ffbf5e89c88ef", size = 30954 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/07/1afa0514c876282bebc1c9aee83c6bb98fe6415cf57b88d9b06e7e29bf9c/Flask_Cors-5.0.0-py2.py3-none-any.whl", hash = "sha256:b9e307d082a9261c100d8fb0ba909eec6a228ed1b60a8315fd85f783d61910bc", size = 14463 },
 ]
 
 [[package]]
@@ -325,6 +341,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0", size = 1231287 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9", size = 1572278 },
+]
+
+[[package]]
+name = "jinja-partials"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/22/f3343b4b58c5001f6deb6b7a9be061e58239822062c175f51d891b0919e0/jinja_partials-0.2.1.tar.gz", hash = "sha256:5b32cc035ee93f372ddfcecf96c4837450d8561d0e2ff26c89dc0d0bd071128b", size = 2970930 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/f3/74e62cdc6b91724826bfcd8cc52de08392fc3973e95d0e1ba11966f82873/jinja_partials-0.2.1-py3-none-any.whl", hash = "sha256:c23a5217251350ef75b8368ce59fa7e43463cd61a11fde1b2c869b2011abb953", size = 4654 },
 ]
 
 [[package]]
@@ -820,7 +848,7 @@ name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737 }
 wheels = [


### PR DESCRIPTION
Ved å lage en funksjon `urn_list_to_corpus` så kan vi cache den delen av excel-lesinga som krever at vi kommuniserer med dhlab-apiet. Dessverre må input være tuppler for at LRU-cachen skal funke, og dhlab-pakka er litt “ømfientlig” for typer så vi må konvertere litt frem og tilbake, men det er ihvertfall ikke merkbart på kjøretiden 🙂

Jeg lager en issue på dhlab-pakka på at `extend_from_identifiers` bør akseptere vilkårlige iterable i fremtiden

Resolves #9