### PR TITLE
Litt opprydding i lastede javascriptfiler

### DIFF
--- a/src/dhlab_corpus_webapp/static/tableinitializer.js
+++ b/src/dhlab_corpus_webapp/static/tableinitializer.js
@@ -5,12 +5,12 @@ function initializeDataTable(filename) {
         buttons: [
             {
                 extend: 'excel',
-                filename: 'korpus'
+                filename: 'korpus',
+                title: null
             },
             {
                 extend: 'csv',
-                title: 'korpus', 
-                bom: true, 
+                filename: 'korpus', 
             }
         ]
     });

--- a/src/dhlab_corpus_webapp/templates/base.html
+++ b/src/dhlab_corpus_webapp/templates/base.html
@@ -21,37 +21,14 @@
     <link href="https://fonts.googleapis.com/css2?family=DM+Mono:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&display=swap" rel="stylesheet">
 
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.3/jszip.min.js"></script>
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/pdfmake.min.js"></script>
-    <!--<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/vfs_fonts.js"></script>-->
-    <!--Scripts for icons-->
     <script type="module" src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.esm.js"></script>
     <script nomodule src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.js"></script>
-
     <script src="https://code.jquery.com/jquery-3.7.1.js"></script>
-    <script src="https://cdn.datatables.net/2.1.8/js/dataTables.js"></script>
+    <script src="https://cdn.datatables.net/2.2.2/js/dataTables.min.js"></script>
     <script src="https://cdn.datatables.net/buttons/3.2.0/js/dataTables.buttons.min.js"></script>
     <script src="https://cdn.datatables.net/buttons/3.2.0/js/buttons.html5.min.js"></script>
 
-    <script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
-
-
-    <link href="https://nightly.datatables.net/css/jquery.dataTables.css" rel="stylesheet" type="text/css" />
-    <script src="https://nightly.datatables.net/js/jquery.dataTables.js"></script>
-    <script src="https://cdn.datatables.net/buttons/1.2.2/js/buttons.html5.js"></script>
     
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.32/pdfmake.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.32/vfs_fonts.js"></script>
-    
-    <link href="https://cdn.datatables.net/buttons/1.5.1/css/buttons.dataTables.css" rel="stylesheet" type="text/css" />
-    <script src="https://cdn.datatables.net/buttons/1.5.1/js/dataTables.buttons.js"></script>
-    <script src="https://cdn.datatables.net/buttons/1.5.1/js/buttons.colVis.min.js"></script>
-    
-    <script src="https://cdn.datatables.net/buttons/1.5.1/js/buttons.colVis.min.js"></script> 
-        <script src="https://cdn.datatables.net/buttons/1.5.2/js/buttons.print.min.js"></script> 
-
-
-    
-
     <title>{{ app_title }}</title>
 
 </head>


### PR DESCRIPTION
Jeg leste på datatables-dokumentasjonen og fant en litt ryddigere måte å fjerne overskriften i excel-fila (vi kan sette `title: null` i `tableinitializer.js`). Da fikk jeg fjernet en del duplikate og (så vidt jeg kunne se) ubrukte javascript-filer også 🙂