### PR TITLE
Use year column when timestamp isna

### DIFF
--- a/src/dhlab_corpus_webapp/app.py
+++ b/src/dhlab_corpus_webapp/app.py
@@ -112,7 +112,11 @@ def parse_timestamp(corpus: pd.DataFrame) -> pd.DataFrame:
 
     def get_timestamp(df: pd.DataFrame) -> pd.Series:
         timestamps = pd.to_datetime(df["timestamp"].astype(str), format="%Y%m%d", errors="coerce")
-        return timestamps.fillna(pd.Timestamp("1900-01-01"))
+        missing_mask = timestamps.isna()
+        if missing_mask.any():
+            year_fallback = pd.to_datetime(df.loc[missing_mask, "year"].astype(str), format="%Y", errors="coerce")
+            timestamps.loc[missing_mask] = year_fallback
+        return timestamps.fillna(pd.NaT)
 
     return corpus.assign(timeformat=get_timeformat, timestamp=get_timestamp)
 

--- a/src/dhlab_corpus_webapp/app.py
+++ b/src/dhlab_corpus_webapp/app.py
@@ -191,7 +191,9 @@ def render_corpus_table_for_request(request: flask.Request) -> str:
     corpus = parse_timestamp(corpus)
     corpus = corpus.assign(
         title=corpus.apply(lambda row: make_url(row.urn, row.title), axis="columns"),
-        timestamp=corpus.apply(lambda row: row.timestamp.strftime(row.timeformat), axis="columns"),
+        timestamp=corpus.apply(
+            lambda row: "Ukjent" if pd.isnull(row.timestamp) else row.timestamp.strftime(row.timeformat), axis="columns"
+        ),
     )[CORPUS_COLUMNS_FULL[doctype]]
     # prepare data and table
     corpus_html = corpus.to_html(table_id="results_table", classes=["display"], border=0, index=False, escape=False)


### PR DESCRIPTION
# Endringer
I app.py, istedenfor å bruke 1900-01-01 når timestamp-kolonna mangler verdier, fall tilbake til year-kolonna. 
Hvis hverken timestamp eller year, bruk pd.NaT (Not a Time)

# Eksempel for å se endringer 
Velg "tidsskrift", skriv "psyk*" i tittelfeltet, skriv 2010 i "Fra år", sett maks antall til 1000, og trykk på "Hent korpustabell". 
Sorter tabellen på "Tidspunkt"-kolonna ascending.  

Resultat appen i prod: 
<img width="1255" height="890" alt="image" src="https://github.com/user-attachments/assets/d849e768-8db3-4731-a8d7-40b0a8a9c449" />


Resultat denne branchen:
<img width="1255" height="890" alt="image" src="https://github.com/user-attachments/assets/5561dc32-5513-4f14-9675-d3e871af0fab" />
