### PR TITLE
Make it easier to switch between functions while preserving output

### DIFF
--- a/src/dhlab_corpus_webapp/app.py
+++ b/src/dhlab_corpus_webapp/app.py
@@ -317,6 +317,7 @@ def create_app() -> Flask:
         return render_template(
             "index.html",
             languages=LANGUAGES,
+            reference_corpora=REFERENCES,
             app_name="Korpusutforsker",
             banner_link_url="readme.html",
             banner_link_text="Om appen",
@@ -339,19 +340,6 @@ def create_app() -> Flask:
             return render_template("corpus_definition/upload_corpus.html")
 
         return render_template("corpus_definition/build_corpus.html", languages=LANGUAGES)
-
-    @app.route("/exploration-method", methods=["GET"])
-    @cross_origin()
-    def exploration_method() -> str | flask.Response:
-        selected_option = request.args.get("method")
-        if selected_option == "table":
-            return render_template("exploration_methods/table.html")
-        elif selected_option == "collocations":
-            return render_template("exploration_methods/collocations.html", reference_corpora=REFERENCES)
-        elif selected_option == "concordance":
-            return render_template("exploration_methods/concordance.html")
-        else:
-            return flask.Response(f"Invalid exploration method {selected_option}", status=400)
 
     @app.route("/explore", methods=["POST"])
     @cross_origin()

--- a/src/dhlab_corpus_webapp/templates/exploration_methods/collocations.html
+++ b/src/dhlab_corpus_webapp/templates/exploration_methods/collocations.html
@@ -1,9 +1,7 @@
-<input type="hidden" name="exploration-method" value="collocations">
-
 <div class="gridded-container">
     <div class="grid-column">
         <label for="search-phrase-collocation">Skriv inn basisord her:</label>
-        <input id="search-phrase-collocation" type="search" name="search" placeholder="Søkeuttrykk" required>
+        <input id="search-phrase-collocation" type="search" name="search" placeholder="Søkeuttrykk" required disabled>
     </div>
 
 

--- a/src/dhlab_corpus_webapp/templates/exploration_methods/concordance.html
+++ b/src/dhlab_corpus_webapp/templates/exploration_methods/concordance.html
@@ -1,17 +1,15 @@
-<input type="hidden" name="exploration-method" value="concordance">
-
 <div class="gridded-container">
     <div class="grid-column">
         <label for="search-phrase-concordance">Skriv inn søkeuttrykk:</label>
-        <input type="search" name="search" id="search-phrase-concordance" placeholder="Søkeuttrykk" required>
+        <input type="search" name="search" id="search-phrase-concordance" placeholder="Søkeuttrykk" required disabled>
     </div>
     <div class="grid-column">
         <label for="window-size-concordance">Vindustørrelse</label>
-        <input type="number" name="window" id="window-concordance" value="20" min="1", max="25" required>
+        <input type="number" name="window" id="window-concordance" value="20" min="1", max="25" required disabled>
     </div>
     <div class="grid-column">
         <label for="limit-concordance">Antall konkordanser:</label>
-        <input type="number" name="limit" id="limit-concordance" value="20" min="1", max="1000" required>
+        <input type="number" name="limit" id="limit-concordance" value="20" min="1", max="1000" required disabled>
     </div>
 </div>
 <input class="build-btn" type="submit" name="update-search" value="Hent konkordanser">

--- a/src/dhlab_corpus_webapp/templates/exploration_methods/table.html
+++ b/src/dhlab_corpus_webapp/templates/exploration_methods/table.html
@@ -1,4 +1,3 @@
-<input type="hidden" name="exploration-method" value="table">
 <span class="table-view-option-container">
     <input type="radio" name="table_mode" value="simple" checked>
     <label for="table-mode-simple">Enkel visning</label>

--- a/src/dhlab_corpus_webapp/templates/index.html
+++ b/src/dhlab_corpus_webapp/templates/index.html
@@ -4,20 +4,35 @@
     {% include 'components/head.html' %}
 
     <title>{{ app_name }}</title>
+    <style>
+        /* CSS rules for showing relevant input and output fields  */
+        .method-fields, .mode-output, .corpus-method-fields { display: none; }
+        .show-table .form-table, .show-table .output-table { display: block; }
+        .show-concordance .form-concordance, .show-concordance .output-concordance { display: block; }
+        .show-collocations .form-collocations, .show-collocations .output-collocations { display: block; }
+        .show-build_corpus .form-build_corpus { display: block; }
+        .show-upload_corpus .form-upload_corpus { display: block; }
+    </style>
 </head>
-<body>
+<body class="show-table">
     <main>
         <header>
             {% include 'components/banner.html' with context %}
             <h1>Bygg og utforsk et DH-LAB-korpus</h1>
 
             <p>
-                Denne appen lar deg bygge et korpus basert på <a target=_blank rel=noopener href="https://www.nb.no/search">Nasjonalbibliotekets samling</a>.
+                Denne appen lar deg bygge et korpus basert på <a target=_blank rel=noopener href="https://www.nb.no">Nasjonalbibliotekets samling</a>.
                 Du kan så velge å vise korpuset direkte som <em>tabell</em> eller dykke dypere og utforske <em>kollokasjoner</em> eller <em>konkordanser</em> i korpuset.
-                Korpustabellen kan også brukes i andre <a target=_blank rel=noopener href="https://www.nb.no/dh-lab/apper/">DH-LAB-apper</a>.
+                Korpustabellen kan også brukes i andre <a target=_blank rel=noopener href="https://www.nb.no">DH-LAB-apper</a>.
             </p>
 
         </header>
+
+        <form id="update-corpus-form"
+            hx-post="{{ url_for('explore_corpus') }}"
+            hx-encoding="multipart/form-data"
+            hx-target="#output-table"
+            hx-indicator="#loading">
 
         <details open>
             <summary>Vis/skjul korpusdefinisjon</summary>
@@ -26,62 +41,85 @@
             <select
                 name="corpus-builder-method"
                 id="corpus-builder-method"
-                hx-get="corpus-definition-method"
-                hx-target="#search-form-corpus"
-                hx-trigger="change, load"
-                hx-request='{"noHeaders": true}'
+                onchange="document.getElementById('search-form-corpus').className = 'show-' + this.value"
             >
                 <option value="build_corpus">Bygg korpus basert på valg</option>
                 <option value="upload_corpus">Last opp korpusdefinisjon</option>
             </select>
 
-            <form id="search-form-corpus">
-                {% include 'corpus_definition/build_corpus.html' with context %}
-            </form>
+            <div id="search-form-corpus" class="show-build_corpus">
+                <div class="corpus-method-fields form-build_corpus">
+                    {% include 'corpus_definition/build_corpus.html' with context %}
+                </div>
+                <div class="corpus-method-fields form-upload_corpus">
+                    {% include 'corpus_definition/upload_corpus.html' with context %}
+                </div>
+            </div>
         </details>
 
 
-            <form
-                id="exploration-method-form"
-                hx-get="exploration-method"
-                hx-target="#update-corpus-form"
-                hx-trigger="change, load"
-                hx-request='{"noHeaders": true}'
-            >
+            <div id="exploration-method-form">
 
                 <span>Utforskingsmetode:</span>
                 <span class="method-option-container">
-                    <input type="radio" id="table" name="method" value="table" checked />
+                    <input type="radio" id="table" name="method-toggle" value="table" checked />
                     <label for="table">Korpustabell</label>
                 </span>
                 <span class="method-option-container">
-                    <input type="radio" id="concordance" name="method" value="concordance" />
+                    <input type="radio" id="concordance" name="method-toggle" value="concordance" />
                     <label for="concordance">Konkordanser</label>
                 </span>
                 <span class="method-option-container">
-                    <input type="radio" id="collocations" name="method" value="collocations" />
+                    <input type="radio" id="collocations" name="method-toggle" value="collocations" />
                     <label for="collocations">Kollokasjoner</label>
                 </span>
-            </form>
+            </div>
 
 
         <div id="corpus-exploration">
-            <form id="update-corpus-form"
-                hx-post="explore"
-                hx-encoding="multipart/form-data"
-                hx-target="#output"
-                hx-trigger="submit"
-                hx-indicator="#loading"
-            >
-            </form>
+            <!-- Hidden state for backend -->
+            <input type="hidden" name="exploration-method" id="active-method" value="table">
+
+            <div class="method-fields form-table">
+                {% include 'exploration_methods/table.html' %}
+            </div>
+            <div class="method-fields form-concordance">
+                {% include 'exploration_methods/concordance.html' %}
+            </div>
+            <div class="method-fields form-collocations">
+                {% include 'exploration_methods/collocations.html' with context %}
+            </div>
+            
             <div id="loading">
                 <div>Henter ut resultater</div>
                 <span class="loader"></span>
             </div>
         </div>
 
-        <div id="output"></div>
+        </form>
+
+        <!-- Output divs -->
+        <div id="output-table" class="mode-output output-table"></div>
+        <div id="output-concordance" class="mode-output output-concordance"></div>
+        <div id="output-collocations" class="mode-output output-collocations"></div>
 
     </main>
+
+    <script>
+        document.addEventListener('change', function(e) {
+            if (e.target.name === 'method-toggle') {
+                const mode = e.target.value;
+                const form = document.getElementById('update-corpus-form');
+                document.body.className = `show-${mode}`;
+                document.getElementById('active-method').value = mode;
+                form.setAttribute('hx-target', `#output-${mode}`);
+                htmx.process(form);
+
+                // Disable hidden inputs to prevent validation blocking
+                form.querySelectorAll('.method-fields input, .method-fields select').forEach(el => el.disabled = true);
+                form.querySelectorAll(`.form-${mode} input, .form-${mode} select`).forEach(el => el.disabled = false);
+            }
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
The goal of the PR is to make it easier to switch between functions of the application. In the current version, the subforms and output fields are cleared upon a switch of the radio buttons. This makes it hard to switch between functions, e.g. collocations and concordances.

Credits to Gemini for help.